### PR TITLE
Comment CI success on PRs so watchers don't need to poll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,23 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+
+  # Announce a green build back on the pull request. The comment produces a
+  # webhook event, so anything watching the PR learns CI passed without polling.
+  notify_success:
+    runs-on: ubuntu-latest
+    needs: [scan_ruby, scan_js, lint, zeitwerk, test]
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment CI success on the pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `✅ CI passed for ${context.payload.pull_request.head.sha}`
+            })

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@ Simpleteam is a set of simple straightforwards tools for developer teams.
 - Creating new HTML View Components components can be performed with `bin/rails g component MyComponentName`
 - Creating new JS controller (if absolutely necessary) can be performed with `bin/rails g stimulus MyControllerName`
 
+## Continuous Integration
+
+- The CI workflow (`.github/workflows/ci.yml`) posts a `✅ CI passed` comment on the
+  pull request once every check succeeds. That comment is delivered as a webhook event.
+- When watching a pull request, always rely on this success comment to confirm CI is
+  green. Do not poll or schedule self check-ins to detect CI success — wait for the
+  webhook.
+
 ## References
 
 - Rails 8 guides and explanations available at https://guides.rubyonrails.org/


### PR DESCRIPTION
## Summary

GitHub webhooks reliably deliver CI **failures**, but not CI **successes** — so anything watching a PR (e.g. an automated agent) has to fall back to polling / scheduled check-ins to learn the build went green.

This adds a `notify_success` job to the CI workflow that runs after every other check passes and posts a `✅ CI passed` comment on the pull request. That comment is itself a webhook event, so watchers are notified of success directly — no polling required.

## Changes

- **`.github/workflows/ci.yml`** — new `notify_success` job:
  - `needs: [scan_ruby, scan_js, lint, zeitwerk, test]`, so it only runs when all checks succeed (a failed dependency skips it).
  - `if: github.event_name == 'pull_request'`, so it only comments on PRs.
  - Scoped `permissions: pull-requests: write` and uses `actions/github-script` to post the comment.
- **`CLAUDE.md`** — documents the convention: when watching a PR, rely on the `✅ CI passed` comment to confirm CI is green rather than polling or scheduling self check-ins.

## Notes

- The comment includes the head SHA so it's clear which commit passed.
- Only fires on the green path; failures are already delivered by GitHub's own webhooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeES7C3scdnuFXRDh2gV1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeES7C3scdnuFXRDh2gV1i)_