### PR TITLE
Data chart fixes + super admin & admin dashboard

### DIFF
--- a/app/components/api_chart_component.rb
+++ b/app/components/api_chart_component.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
 class ApiChartComponent < ApplicationComponent
-  def initialize(name:, team:, keys:, host:)
+  def initialize(name:, team:, keys:, host:, page: 1)
       @name = name
       @team = team
       @keys = keys
       @host = host
+      @page = page
 
       super
   end
 
-  attr_accessor :name, :team, :keys, :host
+  attr_accessor :name, :team, :keys, :host, :page
 
   def call
     tag.div class: "aspect-[3/1] bg-yin-800 rounded-lg py-2 px-4", data: {
@@ -19,7 +20,8 @@ class ApiChartComponent < ApplicationComponent
       api_chart_team_id_value: team.id,
       api_chart_api_key_value: team.data_api_key,
       api_chart_host_value: host,
-      api_chart_keys_value: keys
+      api_chart_keys_value: keys,
+      api_chart_page_value: page
     } do
       tag.canvas class: "w-full h-full", data: {
         api_chart_target: "canvas"

--- a/app/components/pending_seat_component.rb
+++ b/app/components/pending_seat_component.rb
@@ -9,6 +9,6 @@ class PendingSeatComponent < ApplicationComponent
   attr_reader :pending_seat, :user
 
   def owner
-    pending_seat.team.user == user
+    user.owns?(pending_seat.team)
   end
 end

--- a/app/components/team_switcher_component.html.erb
+++ b/app/components/team_switcher_component.html.erb
@@ -6,7 +6,7 @@
     <%= render LinkComponent.new(text: "Status Updates", to: new_team_status_path(team)) %>
     <%= render LinkComponent.new(text: "Data Store", to: team_data_store_path(team)) %>
 
-    <% if team.user == Current.user %>
+    <% if Current.user.owns?(team) %>
       <%= render LinkComponent.new(text: "Team Settings", to: edit_team_path(team)) %>
     <% end %>
   </div>

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,11 @@
+class Admin::BaseController < ApplicationController
+  layout "wide"
+
+  before_action :require_super_admin
+
+  private
+
+  def require_super_admin
+    redirect_to dashboard_path unless Current.user&.super_admin?
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,6 @@
+class Admin::DashboardController < Admin::BaseController
+  def index
+    @team_count = Team.count
+    @user_count = User.count
+  end
+end

--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -1,0 +1,5 @@
+class Admin::TeamsController < Admin::BaseController
+  def index
+    @teams = Team.includes(:user, :seats).order(:name)
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,5 @@
+class Admin::UsersController < Admin::BaseController
+  def index
+    @users = User.order(:email_address)
+  end
+end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -46,9 +46,11 @@ class TeamsController < ApplicationController
   def data_store; end
   def data_store_visualize
     @name = visualize_query_params[:name]
-    @data = DataQueryService.new(team: @team, params: visualize_query_params).call
+    @page = [ visualize_query_params[:page].to_i, 1 ].max
+    @data = DataQueryService.new(team: @team, params: visualize_query_params.merge(page: @page)).call
     @data_keys = @data.first&.content_keys
     @visualize_keys = visualize_keys
+    @has_next_page = @data.length == DataQueryService::DEFAULT_QUERY_PARAMS[:per_page]
 
     render layout: "wide"
   end
@@ -76,7 +78,7 @@ class TeamsController < ApplicationController
   end
 
   def visualize_query_params
-    params.permit(:name)
+    params.permit(:name, :page)
   end
 
   def visualize_keys

--- a/app/javascript/controllers/api_chart_controller.js
+++ b/app/javascript/controllers/api_chart_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
     apiKey: String,
     keys: String,
     host: String,
+    page: Number,
   };
 
   static targets = ["canvas"];
@@ -94,7 +95,11 @@ export default class extends Controller {
       host: this.hostValue,
     });
 
-    const req = await api.list({ name: this.nameValue, order: "desc" });
+    const req = await api.list({
+      name: this.nameValue,
+      order: "desc",
+      page: this.pageValue || 1,
+    });
     const json = await req.json();
 
     // The API returns the most recent entries first. Reverse them so the

--- a/app/javascript/controllers/api_chart_controller.js
+++ b/app/javascript/controllers/api_chart_controller.js
@@ -94,10 +94,12 @@ export default class extends Controller {
       host: this.hostValue,
     });
 
-    const req = await api.list({ name: this.nameValue, order: "asc" });
+    const req = await api.list({ name: this.nameValue, order: "desc" });
     const json = await req.json();
 
-    return json;
+    // The API returns the most recent entries first. Reverse them so the
+    // chart plots the last n entries in chronological order.
+    return json.reverse();
   }
 
   get chartData() {

--- a/app/javascript/controllers/checkbox_group_controller.js
+++ b/app/javascript/controllers/checkbox_group_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="checkbox-group"
+// Provides select-all / deselect-all behavior for a group of checkboxes.
+// Mark each checkbox with data-checkbox-group-target="checkbox".
+export default class extends Controller {
+  static targets = ["checkbox"];
+
+  selectAll() {
+    this.setAll(true);
+  }
+
+  deselectAll() {
+    this.setAll(false);
+  }
+
+  setAll(checked) {
+    this.checkboxTargets.forEach((checkbox) => {
+      checkbox.checked = checked;
+    });
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,11 +24,13 @@ class User < ApplicationRecord
   end
 
   def member_of?(team)
-    self == team.user || self.seats.where(team:).any?
+    owns?(team) || self.seats.where(team:).any?
   end
 
+  # Super admins act as the owner of every team, so they pass every
+  # ownership check regardless of who the team actually belongs to.
   def owns?(team)
-    self == team.user
+    super_admin? || self == team.user
   end
 
   def default_team

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,13 @@
+<%= render SectionHeaderComponent.new(text: "Admin") %>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+  <%= link_to admin_teams_path, class: "border border-yin-600 rounded-lg p-6 flex flex-col gap-1 hover:bg-yin-800" do %>
+    <span class="text-3xl font-bold"><%= @team_count %></span>
+    <span class="text-yin-400">Teams</span>
+  <% end %>
+
+  <%= link_to admin_users_path, class: "border border-yin-600 rounded-lg p-6 flex flex-col gap-1 hover:bg-yin-800" do %>
+    <span class="text-3xl font-bold"><%= @user_count %></span>
+    <span class="text-yin-400">Users</span>
+  <% end %>
+</div>

--- a/app/views/admin/teams/index.html.erb
+++ b/app/views/admin/teams/index.html.erb
@@ -1,0 +1,26 @@
+<%= render SectionHeaderComponent.new(text: "Teams", badge: @teams.size.to_s) %>
+
+<%= render LinkComponent.new(text: "← Admin", to: admin_root_path, style: :text, level: :secondary) %>
+
+<div class="overflow-x-auto">
+  <table class="w-full text-left text-sm border-collapse">
+    <thead>
+      <tr class="border-b border-yin-600 text-yin-400">
+        <th class="py-2 pr-4 font-medium">Name</th>
+        <th class="py-2 pr-4 font-medium">Owner</th>
+        <th class="py-2 pr-4 font-medium">Members</th>
+        <th class="py-2 pr-4 font-medium">Created</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @teams.each do |team| %>
+        <tr class="border-b border-yin-700">
+          <td class="py-2 pr-4"><%= team.name %></td>
+          <td class="py-2 pr-4"><%= team.user&.email_address %></td>
+          <td class="py-2 pr-4"><%= team.member_count %></td>
+          <td class="py-2 pr-4"><%= team.created_at.strftime("%B %d, %Y") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,28 @@
+<%= render SectionHeaderComponent.new(text: "Users", badge: @users.size.to_s) %>
+
+<%= render LinkComponent.new(text: "← Admin", to: admin_root_path, style: :text, level: :secondary) %>
+
+<div class="overflow-x-auto">
+  <table class="w-full text-left text-sm border-collapse">
+    <thead>
+      <tr class="border-b border-yin-600 text-yin-400">
+        <th class="py-2 pr-4 font-medium">Name</th>
+        <th class="py-2 pr-4 font-medium">Email</th>
+        <th class="py-2 pr-4 font-medium">Super Admin</th>
+        <th class="py-2 pr-4 font-medium">Confirmed</th>
+        <th class="py-2 pr-4 font-medium">Created</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr class="border-b border-yin-700">
+          <td class="py-2 pr-4"><%= user.display_name %></td>
+          <td class="py-2 pr-4"><%= user.email_address %></td>
+          <td class="py-2 pr-4"><%= user.super_admin? ? "Yes" : "—" %></td>
+          <td class="py-2 pr-4"><%= user.confirmed? ? "Yes" : "—" %></td>
+          <td class="py-2 pr-4"><%= user.created_at.strftime("%B %d, %Y") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/teams/data_store_visualize.html.erb
+++ b/app/views/teams/data_store_visualize.html.erb
@@ -47,4 +47,25 @@
   <% end %>
 </div>
 
+<% keys_param = params.permit(keys: {})[:keys] %>
+<% if @page > 1 || @has_next_page %>
+  <nav class="flex items-center justify-between gap-4" aria-label="Records pagination">
+    <% if @page > 1 %>
+      <%= render LinkComponent.new(to: team_data_store_visualize_path(@team, @name, page: @page - 1, keys: keys_param),
+                                    text: "← Previous", style: :outlined, level: :secondary) %>
+    <% else %>
+      <span></span>
+    <% end %>
+
+    <span class="text-yin-400 text-sm">Page <%= @page %></span>
+
+    <% if @has_next_page %>
+      <%= render LinkComponent.new(to: team_data_store_visualize_path(@team, @name, page: @page + 1, keys: keys_param),
+                                    text: "Next →", style: :outlined, level: :secondary) %>
+    <% else %>
+      <span></span>
+    <% end %>
+  </nav>
+<% end %>
+
 </section>

--- a/app/views/teams/data_store_visualize.html.erb
+++ b/app/views/teams/data_store_visualize.html.erb
@@ -11,7 +11,8 @@
   <%= render ApiChartComponent.new(name: @name,
                                    team: @team,
                                    keys: @visualize_keys&.join(",") || @data_keys&.join(","),
-                                   host: current_host) %>
+                                   host: current_host,
+                                   page: @page) %>
 
   <div class="mx-auto max-w-2xl container">
 

--- a/app/views/teams/data_store_visualize.html.erb
+++ b/app/views/teams/data_store_visualize.html.erb
@@ -10,23 +10,32 @@
 
   <%= render ApiChartComponent.new(name: @name,
                                    team: @team,
-                                   keys: @visualize_keys&.join(",") || @data_keys&.join(","),
+                                   keys: @visualize_keys&.join(",") || @data_keys&.first,
                                    host: current_host,
                                    page: @page) %>
 
   <div class="mx-auto max-w-2xl container">
 
   <%= form_with url: team_data_store_visualize_path, method: :get, html: {
-    class: "grid grid-cols-2 gap-4"
+    class: "grid grid-cols-2 gap-4",
+    data: { controller: "checkbox-group" }
   } do |form| %>
 
+    <div class="col-span-2 flex gap-4">
+      <%= render ButtonComponent.new(text: "Select all", type: :button, style: :outlined, level: :secondary,
+                                     element: { data: { action: "checkbox-group#selectAll" } }) %>
+      <%= render ButtonComponent.new(text: "Deselect all", type: :button, style: :outlined, level: :secondary,
+                                     element: { data: { action: "checkbox-group#deselectAll" } }) %>
+    </div>
+
     <% @data_keys.each do |key| %>
-      <% checked = @visualize_keys ? @visualize_keys&.include?(key) : true %>
+      <% checked = @visualize_keys ? @visualize_keys&.include?(key) : (key == @data_keys.first) %>
 
       <%= form.label "keys[#{key}]", class: "border p-3 rounded border-yin-600 cursor-pointer auto-rows-auto" do %>
         <%= form.checkbox "keys[#{key}]",
             checked:,
-            include_hidden: false %>
+            include_hidden: false,
+            data: { checkbox_group_target: "checkbox" } %>
         <span><%= key %></span>
       <% end %>
     <% end %>

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render SectionHeaderComponent.new(text: @team.name, badge: @team.user == Current.user ? "Owner" : nil) %>
+<%= render SectionHeaderComponent.new(text: @team.name, badge: Current.user.owns?(@team) ? "Owner" : nil) %>
 
 <section class="flex flex-col gap-2">
   <h2 class="font-bold text-2xl">Add New Seats</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,12 @@ Rails.application.routes.draw do
   get "/dashboard", to: "dashboard#index"
   get "/dashboard/:team_id", to: "dashboard#index"
 
+  namespace :admin do
+    root "dashboard#index"
+    resources :teams, only: :index
+    resources :users, only: :index
+  end
+
   get "up" => "rails/health#show", as: :rails_health_check
 
   namespace :slack do

--- a/db/migrate/20260726000000_add_super_admin_to_users.rb
+++ b/db/migrate/20260726000000_add_super_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddSuperAdminToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :super_admin, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_27_105956) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_26_000000) do
   create_table "data", id: :string, force: :cascade do |t|
     t.string "team_id", null: false
     t.string "name", limit: 120, null: false
@@ -109,6 +109,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_27_105956) do
     t.datetime "confirmed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "super_admin", default: false, null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 


### PR DESCRIPTION
## Summary

This branch bundles several related improvements to the data chart / visualize page plus a new super-admin capability and admin dashboard.

### Data chart & visualize page
- **Show the last _n_ entries, not the first.** The chart previously fetched with `order: "asc"` which, combined with the default `per_page` limit, returned the oldest records. It now fetches most-recent-first (`order: "desc"`) and reverses them so the chart still plots chronologically while showing the latest data.
- **Pagination for the records list (in markup, no JS).** Permitted a `:page` param, plumbed it through `DataQueryService`, and added Previous / Next links plus a page indicator. The links preserve the selected `name` and visualize `keys` across pages.
- **Chart honors the selected page.** The current page is passed from the view into `ApiChartComponent` as a Stimulus value; the only JS added is reading that value and including `page` in the API query, so the chart and the records list stay in sync.
- **Sensible default selection.** On first load only the first data key is selected/fetched (instead of every key), for both the checkboxes and the chart.
- **Select all / Deselect all buttons.** Backed by a new reusable `checkbox-group` Stimulus controller.

### Super admin
- Added a `super_admin` boolean to `users` (default `false`, not mass-assignable — grantable only via console/seed/DB).
- `User#owns?` now returns `true` for super admins, so they pass every ownership gate; `member_of?` and the remaining direct owner display checks route through `owns?` so super admins are treated as owner consistently.

### Admin dashboard (`/admin`)
- Minimal, dependency-free admin area gated to super admins (`Admin::BaseController`).
- `/admin` landing page with team/user counts, `/admin/teams` and `/admin/users` list **every** team and user with no pagination.
- Built with plain ERB tables and existing components — no new gems or JS.

## Migration

Adds `super_admin` to `users`. Run `bin/rails db:migrate` on deploy. `db/schema.rb` is already updated to the post-migration state.

## Testing notes

The container used for this work has no gem bundle, so Rails could not be booted. Changes were verified via Ruby syntax checks and ERB compilation; runtime testing should be done in a normal environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkD3cproxdzW24ZpG2baTc)_