### PR TITLE
Add team name to the daily statuses Slack message

### DIFF
--- a/app/controllers/slack/commands/simple_team_controller.rb
+++ b/app/controllers/slack/commands/simple_team_controller.rb
@@ -52,7 +52,7 @@ module Slack
         else
           {
             response_type: "ephemeral",
-            blocks: BlockFormatter.block_for_statuses(statuses)
+            blocks: BlockFormatter.block_for_statuses(statuses, team:)
           }
         end
       end

--- a/app/jobs/slack_list_status_job.rb
+++ b/app/jobs/slack_list_status_job.rb
@@ -4,7 +4,7 @@ class SlackListStatusJob < ApplicationJob
     return unless team
 
     statuses = team.current_statuses
-    blocks = BlockFormatter.block_for_statuses(statuses)
+    blocks = BlockFormatter.block_for_statuses(statuses, team:)
 
     SlackUser.where(slack_installation_id: team.slack_installation.id).each do |slack_user|
       next unless slack_user.user.all_teams.include? team

--- a/lib/block_formatter.rb
+++ b/lib/block_formatter.rb
@@ -3,8 +3,8 @@
 module BlockFormatter
   module_function
 
-  def block_for_statuses(statuses, show_actions: false)
-    block = [ title_section, divider ]
+  def block_for_statuses(statuses, team:, show_actions: false)
+    block = [ title_section("*#{team.name} Statuses For Today*"), divider ]
     if statuses.blank?
       markdown_block("No statuses have been submitted. :disappointed:")
     else


### PR DESCRIPTION
## Summary

The daily statuses Slack message title now includes the team name, so it reads `<team_name> Statuses For Today` instead of just `Statuses For Today`.

## Changes

- **`lib/block_formatter.rb`** — `block_for_statuses` now takes a required `team:` keyword and builds the title as `"*#{team.name} Statuses For Today*"`.
- **`app/jobs/slack_list_status_job.rb`** and **`app/controllers/slack/commands/simple_team_controller.rb`** — both callers pass `team:` (each already had the team in scope).

## Testing notes

The container used for this work has no gem bundle, so Rails could not be booted. Changes were verified via Ruby syntax checks; runtime/Slack verification should be done in a normal environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkD3cproxdzW24ZpG2baTc)_