### PR TITLE
Add resolution option (full/weekly/monthly/quarterly) to data store view and API

### DIFF
--- a/app/components/api_chart_component.rb
+++ b/app/components/api_chart_component.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 class ApiChartComponent < ApplicationComponent
-  def initialize(name:, team:, keys:, host:, page: 1)
+  def initialize(name:, team:, keys:, host:, page: 1, resolution: "full")
       @name = name
       @team = team
       @keys = keys
       @host = host
       @page = page
+      @resolution = resolution
 
       super
   end
 
-  attr_accessor :name, :team, :keys, :host, :page
+  attr_accessor :name, :team, :keys, :host, :page, :resolution
 
   def call
     tag.div class: "aspect-[3/1] bg-yin-800 rounded-lg py-2 px-4", data: {
@@ -21,7 +22,8 @@ class ApiChartComponent < ApplicationComponent
       api_chart_api_key_value: team.data_api_key,
       api_chart_host_value: host,
       api_chart_keys_value: keys,
-      api_chart_page_value: page
+      api_chart_page_value: page,
+      api_chart_resolution_value: resolution
     } do
       tag.canvas class: "w-full h-full", data: {
         api_chart_target: "canvas"

--- a/app/controllers/data_controller.rb
+++ b/app/controllers/data_controller.rb
@@ -37,7 +37,7 @@ class DataController < ApplicationController
   private
 
   def query_params
-    params.permit(:name, :per_page, :page, :order)
+    params.permit(:name, :per_page, :page, :order, :resolution)
   end
 
   def create_params

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -47,6 +47,7 @@ class TeamsController < ApplicationController
   def data_store_visualize
     @name = visualize_query_params[:name]
     @page = [ visualize_query_params[:page].to_i, 1 ].max
+    @resolution = DataQueryService::RESOLUTIONS.include?(visualize_query_params[:resolution]) ? visualize_query_params[:resolution] : "full"
     @data = DataQueryService.new(team: @team, params: visualize_query_params.merge(page: @page)).call
     @data_keys = @data.first&.content_keys
     @visualize_keys = visualize_keys
@@ -78,7 +79,7 @@ class TeamsController < ApplicationController
   end
 
   def visualize_query_params
-    params.permit(:name, :page)
+    params.permit(:name, :page, :resolution)
   end
 
   def visualize_keys

--- a/app/javascript/controllers/api_chart_controller.js
+++ b/app/javascript/controllers/api_chart_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
     keys: String,
     host: String,
     page: Number,
+    resolution: String,
   };
 
   static targets = ["canvas"];
@@ -99,6 +100,7 @@ export default class extends Controller {
       name: this.nameValue,
       order: "desc",
       page: this.pageValue || 1,
+      resolution: this.resolutionValue || "full",
     });
     const json = await req.json();
 

--- a/app/services/data_query_service.rb
+++ b/app/services/data_query_service.rb
@@ -3,8 +3,11 @@ class DataQueryService
     per_page: 30,
     page: 1,
     order: "desc",
-    name: nil
+    name: nil,
+    resolution: "full"
   }.freeze
+
+  RESOLUTIONS = %w[full weekly monthly quarterly].freeze
 
   def initialize(team:, params:)
     @team = team
@@ -12,25 +15,60 @@ class DataQueryService
   end
 
   def call
-    where_args = {
-      team: @team
-    }
+    return paginate(base_scope.order(created_at: order)) if resolution == "full"
 
-    where_args[:name] = query_params[:name] if query_params[:name]
-
-    Datum.where(**where_args)
-      .order(created_at: query_params[:order].to_sym)
-      .offset(page_offset)
-      .limit(query_params[:per_page])
+    records = collapse_by_period(base_scope.order(created_at: :asc).to_a)
+    records.reverse! if order == :desc
+    records[page_offset, per_page] || []
   end
 
   private
+
+  def base_scope
+    where_args = { team: @team }
+    where_args[:name] = query_params[:name] if query_params[:name]
+
+    Datum.where(**where_args)
+  end
+
+  def paginate(scope)
+    scope.offset(page_offset).limit(per_page)
+  end
+
+  # Keep only the earliest entry within each week/month/quarter. `records` must
+  # be ordered by created_at ascending so the first of each group is the earliest.
+  def collapse_by_period(records)
+    records.group_by { |datum| period_key(datum.created_at) }.values.map(&:first)
+  end
+
+  def period_key(time)
+    case resolution
+    when "weekly"
+      date = time.to_date
+      [ date.cwyear, date.cweek ]
+    when "monthly" then [ time.year, time.month ]
+    when "quarterly" then [ time.year, (time.month - 1) / 3 ]
+    end
+  end
+
+  def resolution
+    resolution = query_params[:resolution].to_s
+    RESOLUTIONS.include?(resolution) ? resolution : "full"
+  end
+
+  def order
+    query_params[:order].to_sym
+  end
+
+  def per_page
+    query_params[:per_page].to_i
+  end
 
   def query_params
     @query_params ||= DEFAULT_QUERY_PARAMS.merge(@params)
   end
 
   def page_offset
-    query_params[:per_page].to_i * (query_params[:page].to_i - 1)
+    per_page * (query_params[:page].to_i - 1)
   end
 end

--- a/app/views/teams/data_store_visualize.html.erb
+++ b/app/views/teams/data_store_visualize.html.erb
@@ -12,7 +12,8 @@
                                    team: @team,
                                    keys: @visualize_keys&.join(",") || @data_keys&.first,
                                    host: current_host,
-                                   page: @page) %>
+                                   page: @page,
+                                   resolution: @resolution) %>
 
   <div class="mx-auto max-w-2xl container">
 
@@ -20,6 +21,14 @@
     class: "grid grid-cols-2 gap-4",
     data: { controller: "checkbox-group" }
   } do |form| %>
+
+    <label class="col-span-2 flex flex-col gap-1">
+      <span class="text-sm text-yin-400">Resolution</span>
+      <%= form.select :resolution,
+            options_for_select(DataQueryService::RESOLUTIONS.map { |r| [ r.titleize, r ] }, @resolution),
+            {},
+            class: "border p-3 rounded border-yin-600 bg-yin-800 text-white" %>
+    </label>
 
     <div class="col-span-2 flex gap-4">
       <%= render ButtonComponent.new(text: "Select all", type: :button, style: :outlined, level: :secondary,
@@ -61,7 +70,7 @@
 <% if @page > 1 || @has_next_page %>
   <nav class="flex items-center justify-between gap-4" aria-label="Records pagination">
     <% if @page > 1 %>
-      <%= render LinkComponent.new(to: team_data_store_visualize_path(@team, @name, page: @page - 1, keys: keys_param),
+      <%= render LinkComponent.new(to: team_data_store_visualize_path(@team, @name, page: @page - 1, keys: keys_param, resolution: @resolution),
                                     text: "← Previous", style: :outlined, level: :secondary) %>
     <% else %>
       <span></span>
@@ -70,7 +79,7 @@
     <span class="text-yin-400 text-sm">Page <%= @page %></span>
 
     <% if @has_next_page %>
-      <%= render LinkComponent.new(to: team_data_store_visualize_path(@team, @name, page: @page + 1, keys: keys_param),
+      <%= render LinkComponent.new(to: team_data_store_visualize_path(@team, @name, page: @page + 1, keys: keys_param, resolution: @resolution),
                                     text: "Next →", style: :outlined, level: :secondary) %>
     <% else %>
       <span></span>


### PR DESCRIPTION
## Summary

Adds a **Resolution** option to the data store visualize page and the data API, controlling how much of a series is returned:

- **Full** — current behavior, every entry.
- **Weekly** — the first (earliest) entry of each ISO week.
- **Monthly** — the first (earliest) entry of each month.
- **Quarterly** — the first (earliest) entry of each quarter.

## Changes

- **`app/services/data_query_service.rb`** — accepts a `resolution` param (defaults to `full`, invalid values fall back to `full`). For the collapsed resolutions it loads the series ascending, groups by period (ISO week / month / quarter), keeps the first entry per group, then applies the requested order and pagination. `full` keeps the original relation-based query untouched.
- **`app/controllers/data_controller.rb`** — permits `:resolution` on the API `index` endpoint. The existing `data_api.js` client forwards arbitrary params, so API consumers can pass `resolution` with no client change.
- **`app/controllers/teams_controller.rb`** — permits `:resolution` on the visualize action and exposes a normalized `@resolution`.
- **`app/views/teams/data_store_visualize.html.erb`** — a native `<select>` Resolution control in the visualize form; the selection is preserved across the Previous/Next pagination links and passed to the chart.
- **`app/components/api_chart_component.rb`** + **`app/javascript/controllers/api_chart_controller.js`** — the chart receives the resolution as a Stimulus value and includes it in its API query, so the chart matches the selected resolution.

## Notes

- "First entry" is interpreted as the earliest record within each period, so each period contributes one representative data point regardless of display order.
- The collapsed resolutions group in Ruby (DB-agnostic) rather than via DB-specific date SQL.

## Testing notes

The container used for this work has no gem bundle, so Rails could not be booted. Changes were verified via Ruby syntax checks and parse checks of the embedded view expressions; runtime testing should be done in a normal environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkD3cproxdzW24ZpG2baTc)_