### PR TITLE
Team rename + delete, and de-duplicate teams for owners

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -4,7 +4,7 @@ class TeamsController < ApplicationController
 
   before_action :find_team, except: %i[new create]
   user_must_have_seat only: %i[show create_api_key]
-  user_must_own_team only: %i[edit update]
+  user_must_own_team only: %i[edit update destroy]
 
   def new
     @team = Team.new(user: Current.user)
@@ -31,6 +31,12 @@ class TeamsController < ApplicationController
     else
       redirect_to team_data_path(@team), alert: "Something went wrong!"
     end
+  end
+
+  def destroy
+    @team.destroy
+
+    redirect_to dashboard_path, notice: "Team deleted."
   end
 
   def create_api_key

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,6 +5,8 @@ class Team < ApplicationRecord
   belongs_to :user
   has_many :seats, dependent: :destroy
   has_many :pending_seats, dependent: :destroy
+  has_many :statuses, dependent: :destroy
+  has_many :data, class_name: "Datum", dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 120 }
   validates :time_zone, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,9 @@ class User < ApplicationRecord
   end
 
   def all_teams
-    [ *self.teams, *self.seats.map { |seat| seat.team } ]
+    # An owner can also hold a seat on their own team, so dedupe to avoid
+    # listing (and notifying for) the same team twice.
+    [ *self.teams, *self.seats.map { |seat| seat.team } ].uniq
   end
 
   def all_alone?

--- a/app/services/team_update_service.rb
+++ b/app/services/team_update_service.rb
@@ -8,13 +8,14 @@ class TeamUpdateService
   attr_accessor :team, :update
 
   def call
+    name = collect_name
     sections = collect_sections
     end_of_day = collect_time("end_of_day")
     notification_time = collect_time("notification_time")
     time_zone = collect_time_zone
     metadata = collect_metadata
 
-    valid_updates = { sections:, end_of_day:, notification_time:, time_zone:, metadata: }.compact
+    valid_updates = { name:, sections:, end_of_day:, notification_time:, time_zone:, metadata: }.compact
 
     return unless valid_updates.length.positive?
 
@@ -22,6 +23,14 @@ class TeamUpdateService
   end
 
   private
+
+  def collect_name
+    name = update["name"]
+    # Ignore a blank name so the update can't wipe out a required value.
+    return if name.blank?
+
+    name.strip
+  end
 
   def collect_sections
     incoming_sections = update.select { |key| key.include? "section_" }

--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -27,10 +27,17 @@
 </section>
 
 <section class="flex flex-col gap-4">
-  <h2 class="font-bold text-2xl">Status Sections</h2>
+  <h2 class="font-bold text-2xl">Team Settings</h2>
 
   <%= form_with model: @team, url: team_path(@team), method: :patch, html: { class: "flex flex-col gap-8" } do |form| %>
     <fieldset class="flex flex-col gap-4">
+      <h2 class="font-bold text-2xl">Team Name</h2>
+
+      <%= form.text_field :name, value: @team.name, placeholder: "Team Name", class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 w-full" %>
+    </fieldset>
+
+    <fieldset class="flex flex-col gap-4">
+      <h2 class="font-bold text-2xl">Status Sections</h2>
       <% @team.sections.each_with_index do |section, index| %>
       <div class="border border-gray-400 rounded-md">
         <%= form.text_field "section_#{index}_name", value: section["name"], placeholder: "Section Name", class: "block rounded-md focus:outline-solid focus:outline-blue-600 px-3 py-2 font-bold w-full" %>
@@ -76,4 +83,18 @@
 
   <% end %>
 
+</section>
+
+<section class="flex flex-col gap-4">
+  <h2 class="font-bold text-2xl">Danger Zone</h2>
+
+  <p class="text-sm text-yin-300">Deleting a team permanently removes its statuses, data, and members. This cannot be undone.</p>
+
+  <div>
+    <%= button_to "Delete Team",
+          team_path(@team),
+          method: :delete,
+          class: "cursor-pointer w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 inline-block font-medium bg-red-600 hover:bg-red-700 text-white",
+          form: { data: { turbo_confirm: "Delete #{@team.name}? This permanently removes the team, its statuses, and its data." } } %>
+  </div>
 </section>

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -1,6 +1,72 @@
 require "test_helper"
+require "securerandom"
 
 class TeamsControllerTest < ActionDispatch::IntegrationTest
+  test "owner sees the name input and delete button on the edit page" do
+    team = teams(:basic)
+    sign_in(users(:owner))
+
+    get edit_team_path(team)
+
+    assert_response :success
+    assert_select "input[name='team[name]']"
+    assert_select "form[action='#{team_path(team)}'] input[name='_method'][value='delete']"
+  end
+
+  test "owner can rename their team" do
+    team = teams(:basic)
+    sign_in(users(:owner))
+
+    patch team_path(team), params: { team: { name: "Renamed Team" } }
+
+    assert_equal "Renamed Team", team.reload.name
+    assert_response :found
+  end
+
+  test "owner can delete their team" do
+    team = teams(:basic)
+    sign_in(users(:owner))
+
+    assert_difference -> { Team.where(id: team.id).count }, -1 do
+      delete team_path(team)
+    end
+
+    assert_redirected_to dashboard_path
+  end
+
+  test "deleting a team removes its statuses and data" do
+    team = teams(:basic)
+    Status.create!(id: SecureRandom.uuid, user: users(:owner), team:)
+    Datum.create!(id: SecureRandom.uuid, team:, name: "metric")
+    sign_in(users(:owner))
+
+    delete team_path(team)
+
+    assert_not Team.exists?(team.id)
+    assert_empty Status.where(team_id: team.id)
+    assert_empty Datum.where(team_id: team.id)
+  end
+
+  test "a member can not delete a team they do not own" do
+    team = teams(:basic)
+    sign_in(users(:member))
+
+    delete team_path(team)
+
+    assert Team.exists?(team.id)
+    assert_redirected_to dashboard_path
+  end
+
+  test "a non-member can not delete a team" do
+    team = teams(:basic)
+    sign_in(users(:rando))
+
+    delete team_path(team)
+
+    assert Team.exists?(team.id)
+    assert_redirected_to dashboard_path
+  end
+
   test "can create an api key" do
     team = teams(:basic)
     user = users(:owner)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,12 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "all_teams lists a team once when the owner also holds a seat on it" do
+    user = users(:owner)
+    team = teams(:basic)
+    Seat.create!(user:, team:)
+
+    assert_equal 1, user.all_teams.count { |t| t == team }
+    assert_equal user.all_teams.length, user.all_teams.uniq.length
+  end
 end

--- a/test/services/team_update_service_test.rb
+++ b/test/services/team_update_service_test.rb
@@ -22,6 +22,26 @@ class TeamUpdateServiceTest < ActiveSupport::TestCase
     assert_equal expected, team.sections
   end
 
+  test "should collect the name from params" do
+    team = teams(:basic)
+
+    TeamUpdateService.new(team, { "name" => "  Renamed Team  " }).call
+
+    assert_equal "Renamed Team", team.reload.name
+  end
+
+  test "should ignore a blank name" do
+    team = teams(:basic)
+    original = team.name
+
+    TeamUpdateService.new(team, {
+      "name" => "",
+      "project_management_url" => "https://example.com/keep-update-valid"
+    }).call
+
+    assert_equal original, team.reload.name
+  end
+
   test "should collect end_of_day from params" do
     team = teams(:basic)
 


### PR DESCRIPTION
## Summary

Three related team-management changes, all owner-facing.

### 1. Rename a team from the settings page
Adds a **Team Name** input to the top of the team settings form. The value posts through `TeamUpdateService`, which now persists a stripped name and **ignores blank input** so a required name can't be wiped out.

### 2. Delete a team (owner-only, with confirmation)
Adds a **Danger Zone → Delete Team** `button_to` that uses Turbo's `data-turbo-confirm` for a confirmation step before deleting. The edit page is already owner-gated (`user_must_own_team`), and `destroy` is now covered by that same guard.

Deleting a team **cascades** to its statuses and data via new `dependent: :destroy` associations — without this, `statuses`/`data` foreign keys would have blocked the delete.

### 3. Fix teams double-listed for owners who also hold a seat
`User#all_teams` combined owned teams with seat teams without de-duplicating, so an owner who also has a seat on their own team saw it twice (and received two daily digests). `all_teams` now `.uniq`s the result. This matches the duplicate `team-apollo` cards seen on the dashboard.

## Changes
- `app/views/teams/edit.html.erb` — Team Name input; Danger Zone delete button; section header renamed to "Team Settings".
- `app/services/team_update_service.rb` — `collect_name` (strips, ignores blank).
- `app/controllers/teams_controller.rb` — `destroy` action; `user_must_own_team` now includes `destroy`.
- `app/models/team.rb` — `has_many :statuses` / `:data` with `dependent: :destroy`.
- `app/models/user.rb` — `all_teams` de-duplicates.

## Tests
- Owner sees the name input + delete button on the edit page.
- Owner can rename; owner can delete; delete cascades to statuses and data.
- A member (seat, non-owner) and a non-member cannot delete.
- `TeamUpdateService` persists a stripped name and ignores a blank name.
- `User#all_teams` lists a team once when the owner also holds a seat.

Full suite passes (the 5 pre-existing `RegistrationsControllerTest` errors are unrelated — missing encryption key / captcha config in the sandbox — and fail identically on `main`). Rubocop and erb_lint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeES7C3scdnuFXRDh2gV1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeES7C3scdnuFXRDh2gV1i)_