### PR TITLE
Fix team update flash redirect; add super-admin team delete + Slack installs list

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,5 +2,6 @@ class Admin::DashboardController < Admin::BaseController
   def index
     @team_count = Team.count
     @user_count = User.count
+    @slack_installation_count = SlackInstallation.count
   end
 end

--- a/app/controllers/admin/slack_installations_controller.rb
+++ b/app/controllers/admin/slack_installations_controller.rb
@@ -1,0 +1,5 @@
+class Admin::SlackInstallationsController < Admin::BaseController
+  def index
+    @slack_installations = SlackInstallation.includes(:user, :teams).order(:name)
+  end
+end

--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -2,4 +2,11 @@ class Admin::TeamsController < Admin::BaseController
   def index
     @teams = Team.includes(:user, :seats).order(:name)
   end
+
+  def destroy
+    team = Team.find(params[:id])
+    team.destroy
+
+    redirect_to admin_teams_path, notice: "Team deleted.", status: :see_other
+  end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -26,17 +26,21 @@ class TeamsController < ApplicationController
   def update
     success = TeamUpdateService.new(@team, update_params).call
 
+    # Turbo submits this form with PATCH; a 302 would be followed with PATCH
+    # again (per the Fetch spec), so use 303 See Other to force a GET of the
+    # redirect target. team_data_path is a JSON API endpoint, so send the user
+    # back to the settings page where the flash actually renders.
     if success
-      redirect_to team_data_path(@team), notice: "Team updated!"
+      redirect_to edit_team_path(@team), notice: "Team updated!", status: :see_other
     else
-      redirect_to team_data_path(@team), alert: "Something went wrong!"
+      redirect_to edit_team_path(@team), alert: "Something went wrong!", status: :see_other
     end
   end
 
   def destroy
     @team.destroy
 
-    redirect_to dashboard_path, notice: "Team deleted."
+    redirect_to dashboard_path, notice: "Team deleted.", status: :see_other
   end
 
   def create_api_key

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -10,4 +10,9 @@
     <span class="text-3xl font-bold"><%= @user_count %></span>
     <span class="text-yin-400">Users</span>
   <% end %>
+
+  <%= link_to admin_slack_installations_path, class: "border border-yin-600 rounded-lg p-6 flex flex-col gap-1 hover:bg-yin-800" do %>
+    <span class="text-3xl font-bold"><%= @slack_installation_count %></span>
+    <span class="text-yin-400">Slack Installations</span>
+  <% end %>
 </div>

--- a/app/views/admin/slack_installations/index.html.erb
+++ b/app/views/admin/slack_installations/index.html.erb
@@ -1,0 +1,32 @@
+<%= render SectionHeaderComponent.new(text: "Slack Installations", badge: @slack_installations.size.to_s) %>
+
+<%= render LinkComponent.new(text: "← Admin", to: admin_root_path, style: :text, level: :secondary) %>
+
+<div class="overflow-x-auto">
+  <table class="w-full text-left text-sm border-collapse">
+    <thead>
+      <tr class="border-b border-yin-600 text-yin-400">
+        <th class="py-2 pr-4 font-medium">Name</th>
+        <th class="py-2 pr-4 font-medium">Installed By</th>
+        <th class="py-2 pr-4 font-medium">Teams</th>
+        <th class="py-2 pr-4 font-medium">Status</th>
+        <th class="py-2 pr-4 font-medium">Created</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @slack_installations.each do |installation| %>
+        <tr class="border-b border-yin-700">
+          <td class="py-2 pr-4"><%= installation.name.presence || "—" %></td>
+          <td class="py-2 pr-4"><%= installation.user&.email_address || "—" %></td>
+          <td class="py-2 pr-4"><%= installation.teams.size %></td>
+          <td class="py-2 pr-4"><%= installation.active? ? "Active" : "Inactive" %></td>
+          <td class="py-2 pr-4"><%= installation.created_at.strftime("%B %d, %Y") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @slack_installations.empty? %>
+    <%= render EmptySectionNoticeComponent.new(text: "No Slack installations yet.") %>
+  <% end %>
+</div>

--- a/app/views/admin/teams/index.html.erb
+++ b/app/views/admin/teams/index.html.erb
@@ -10,6 +10,7 @@
         <th class="py-2 pr-4 font-medium">Owner</th>
         <th class="py-2 pr-4 font-medium">Members</th>
         <th class="py-2 pr-4 font-medium">Created</th>
+        <th class="py-2 pr-4 font-medium sr-only">Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -19,6 +20,13 @@
           <td class="py-2 pr-4"><%= team.user&.email_address %></td>
           <td class="py-2 pr-4"><%= team.member_count %></td>
           <td class="py-2 pr-4"><%= team.created_at.strftime("%B %d, %Y") %></td>
+          <td class="py-2 pr-4 text-right">
+            <%= button_to "Delete",
+                  admin_team_path(team),
+                  method: :delete,
+                  class: "cursor-pointer rounded-md px-3 py-1.5 font-medium bg-red-600 hover:bg-red-700 text-white",
+                  form: { data: { turbo_confirm: "Delete #{team.name}? This permanently removes the team, its statuses, and its data." } } %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,8 +34,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root "dashboard#index"
-    resources :teams, only: :index
+    resources :teams, only: %i[index destroy]
     resources :users, only: :index
+    resources :slack_installations, only: :index
   end
 
   get "up" => "rails/health#show", as: :rails_health_check

--- a/test/controllers/admin/slack_installations_controller_test.rb
+++ b/test/controllers/admin/slack_installations_controller_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Admin::SlackInstallationsControllerTest < ActionDispatch::IntegrationTest
+  test "super admin can list slack installations" do
+    sign_in(users(:super_admin))
+
+    get admin_slack_installations_path
+
+    assert_response :success
+    assert_select "td", text: "Default Slack App"
+    assert_select "td", text: "Inactive Slack App"
+  end
+
+  test "a non super admin is redirected away from slack installations" do
+    sign_in(users(:owner))
+
+    get admin_slack_installations_path
+
+    assert_redirected_to dashboard_path
+  end
+end

--- a/test/controllers/admin/teams_controller_test.rb
+++ b/test/controllers/admin/teams_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Admin::TeamsControllerTest < ActionDispatch::IntegrationTest
+  test "super admin can list teams" do
+    sign_in(users(:super_admin))
+
+    get admin_teams_path
+
+    assert_response :success
+  end
+
+  test "super admin can delete a team" do
+    team = teams(:basic)
+    sign_in(users(:super_admin))
+
+    assert_difference -> { Team.where(id: team.id).count }, -1 do
+      delete admin_team_path(team)
+    end
+
+    assert_response :see_other
+    assert_redirected_to admin_teams_path
+  end
+
+  test "a non super admin can not delete a team through the admin area" do
+    team = teams(:basic)
+    sign_in(users(:owner))
+
+    delete admin_team_path(team)
+
+    assert Team.exists?(team.id)
+    assert_redirected_to dashboard_path
+  end
+end

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -20,7 +20,19 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     patch team_path(team), params: { team: { name: "Renamed Team" } }
 
     assert_equal "Renamed Team", team.reload.name
-    assert_response :found
+  end
+
+  test "updating a team redirects to settings with a flash notice using see_other" do
+    team = teams(:basic)
+    sign_in(users(:owner))
+
+    patch team_path(team), params: { team: { name: "Renamed Team" } }
+
+    # 303 See Other so Turbo follows the PATCH redirect with a GET instead of
+    # re-issuing PATCH to the target.
+    assert_response :see_other
+    assert_redirected_to edit_team_path(team)
+    assert_equal "Team updated!", flash[:notice]
   end
 
   test "owner can delete their team" do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -27,3 +27,10 @@ other_owner:
   email_address: "somebody@else.com"
   password_digest: "123abc"
   confirmed_at: "Sat, 17 May 2025 18:44:15 +0000"
+
+super_admin:
+  name: "Super Admin"
+  email_address: "admin@simpleteam.dev"
+  password_digest: "abc123"
+  confirmed_at: "Sat, 17 May 2025 18:44:15 +0000"
+  super_admin: true


### PR DESCRIPTION
## Summary

Three changes.

### 1. Team settings save now redirects and shows its flash
`teams#update` redirected to `team_data_path`, which is a **JSON API endpoint** (`data#index`, gated by `ensure_json_request` + `validate_api_key`) — not a user-facing page — so the `notice`/`alert` flash was never rendered.

Two fixes:
- Redirect to `edit_team_path` (the settings page) so the flash renders where the user is.
- Return **303 See Other** on `update` and `destroy`. These forms submit via Turbo as **PATCH/DELETE**; per the Fetch spec a `302` is followed with the *original* method, so the redirect hit a GET-only route and was silently dropped (the behavior you saw — no redirect, no flash). `303` forces the redirect to be followed with a `GET`. (This also fixes the team delete button added in #67, which had the same latent DELETE+302 issue.)

### 2. Delete button on the super-admin teams page
Adds a **Delete** button (with a Turbo confirmation step) to each row of the admin teams table, backed by a new `Admin::TeamsController#destroy`. Gated by the existing `Admin::BaseController` super-admin check.

### 3. Slack installations on the super-admin page
Adds an admin **Slack Installations** list — a new `Admin::SlackInstallationsController#index` with a table (name, installed-by, team count, active status, created), plus a count card on the admin dashboard alongside Teams and Users.

## Changes
- `app/controllers/teams_controller.rb` — update redirects to settings; `update`/`destroy` use `status: :see_other`.
- `config/routes.rb` — `admin/teams#destroy`; `admin/slack_installations#index`.
- `app/controllers/admin/teams_controller.rb` — `destroy`.
- `app/controllers/admin/slack_installations_controller.rb` + view — new list.
- `app/controllers/admin/dashboard_controller.rb` + view — Slack installations count card.
- `app/views/admin/teams/index.html.erb` — delete button column.

## Tests
- `teams#update` responds `303`, redirects to `edit_team_path`, sets the `"Team updated!"` notice.
- Super admin can list and delete teams via the admin area; a non-super-admin is redirected to the dashboard.
- Super admin can list Slack installations (shows the fixtures); a non-super-admin is redirected.
- Added a `super_admin` user fixture.

Full suite passes (the 5 pre-existing `RegistrationsControllerTest` errors are unrelated sandbox encryption/captcha config and fail identically on `main`). Rubocop and erb_lint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeES7C3scdnuFXRDh2gV1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeES7C3scdnuFXRDh2gV1i)_