### PR TITLE
Add scheduled + sent notification visibility to the admin dashboard

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,5 +3,6 @@ class Admin::DashboardController < Admin::BaseController
     @team_count = Team.count
     @user_count = User.count
     @slack_installation_count = SlackInstallation.count
+    @notifications_sent_today = Notification.where(created_at: Time.current.beginning_of_day..).count
   end
 end

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -1,0 +1,22 @@
+class Admin::NotificationsController < Admin::BaseController
+  SENT_LIMIT = 50
+
+  def index
+    @scheduled = scheduled_notifications
+    @sent = Notification.includes(:team).recent.limit(SENT_LIMIT)
+  end
+
+  private
+
+  # Only teams attached to a Slack installation get scheduled, mirroring
+  # DailyScheduleListStatusJob / DailyScheduleStatusReminderJob. The reminder
+  # fires an hour before the digest, matching the jobs.
+  def scheduled_notifications
+    Team.where.not(slack_installation_id: nil).includes(:slack_installation).flat_map do |team|
+      [
+        { team:, kind: Notification::STATUS_REMINDER, at: team.notification_time - 1.hour },
+        { team:, kind: Notification::STATUS_LIST, at: team.notification_time }
+      ]
+    end.sort_by { |entry| entry[:at] }
+  end
+end

--- a/app/jobs/slack_list_status_job.rb
+++ b/app/jobs/slack_list_status_job.rb
@@ -6,10 +6,14 @@ class SlackListStatusJob < ApplicationJob
     statuses = team.current_statuses
     blocks = BlockFormatter.block_for_statuses(statuses, team:)
 
+    recipient_count = 0
     SlackUser.where(slack_installation_id: team.slack_installation.id).each do |slack_user|
       next unless slack_user.user.all_teams.include? team
 
       team.slack_installation.slack_client.chat_postMessage(channel: slack_user.slack_user_id, blocks:)
+      recipient_count += 1
     end
+
+    team.notifications.create!(kind: Notification::STATUS_LIST, recipient_count:)
   end
 end

--- a/app/jobs/slack_status_reminder_job.rb
+++ b/app/jobs/slack_status_reminder_job.rb
@@ -6,6 +6,7 @@ class SlackStatusReminderJob < ApplicationJob
     statuses = team.current_statuses
     blocks = BlockFormatter.block_for_status_reminder
 
+    recipient_count = 0
     SlackUser.where(slack_installation_id: team.slack_installation.id).each do |slack_user|
       next unless slack_user.user.all_teams.include? team
       next if statuses.any? { |s| s.user == slack_user.user }
@@ -13,6 +14,9 @@ class SlackStatusReminderJob < ApplicationJob
       team.slack_installation.slack_client.chat_postEphemeral(channel: team.name,
                                                               user: slack_user.slack_user_id,
                                                               blocks:)
+      recipient_count += 1
     end
+
+    team.notifications.create!(kind: Notification::STATUS_REMINDER, recipient_count:)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,19 @@
+class Notification < ApplicationRecord
+  STATUS_LIST = "status_list".freeze
+  STATUS_REMINDER = "status_reminder".freeze
+
+  LABELS = {
+    STATUS_LIST => "Daily digest",
+    STATUS_REMINDER => "Status reminder"
+  }.freeze
+
+  belongs_to :team
+
+  validates :kind, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+
+  def label
+    LABELS.fetch(kind, kind)
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -7,6 +7,7 @@ class Team < ApplicationRecord
   has_many :pending_seats, dependent: :destroy
   has_many :statuses, dependent: :destroy
   has_many :data, class_name: "Datum", dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 120 }
   validates :time_zone, presence: true

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -15,4 +15,9 @@
     <span class="text-3xl font-bold"><%= @slack_installation_count %></span>
     <span class="text-yin-400">Slack Installations</span>
   <% end %>
+
+  <%= link_to admin_notifications_path, class: "border border-yin-600 rounded-lg p-6 flex flex-col gap-1 hover:bg-yin-800" do %>
+    <span class="text-3xl font-bold"><%= @notifications_sent_today %></span>
+    <span class="text-yin-400">Notifications sent today</span>
+  <% end %>
 </div>

--- a/app/views/admin/notifications/index.html.erb
+++ b/app/views/admin/notifications/index.html.erb
@@ -1,0 +1,64 @@
+<%= render SectionHeaderComponent.new(text: "Notifications") %>
+
+<%= render LinkComponent.new(text: "← Admin", to: admin_root_path, style: :text, level: :secondary) %>
+
+<section class="flex flex-col gap-2">
+  <h2 class="font-bold text-2xl">Scheduled</h2>
+  <p class="text-sm text-yin-400">Next daily reminder and digest for each team, in the team's time zone. Sends run on weekdays.</p>
+
+  <div class="overflow-x-auto">
+    <table class="w-full text-left text-sm border-collapse">
+      <thead>
+        <tr class="border-b border-yin-600 text-yin-400">
+          <th class="py-2 pr-4 font-medium">Team</th>
+          <th class="py-2 pr-4 font-medium">Type</th>
+          <th class="py-2 pr-4 font-medium">Next send</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @scheduled.each do |entry| %>
+          <tr class="border-b border-yin-700">
+            <td class="py-2 pr-4"><%= entry[:team].name.presence || "—" %></td>
+            <td class="py-2 pr-4"><%= Notification::LABELS.fetch(entry[:kind], entry[:kind]) %></td>
+            <td class="py-2 pr-4"><%= entry[:at].strftime("%a %b %-d, %-I:%M %p %Z") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <% if @scheduled.empty? %>
+      <%= render EmptySectionNoticeComponent.new(text: "No teams are connected to Slack yet.") %>
+    <% end %>
+  </div>
+</section>
+
+<section class="flex flex-col gap-2">
+  <h2 class="font-bold text-2xl">Recently Sent</h2>
+
+  <div class="overflow-x-auto">
+    <table class="w-full text-left text-sm border-collapse">
+      <thead>
+        <tr class="border-b border-yin-600 text-yin-400">
+          <th class="py-2 pr-4 font-medium">Team</th>
+          <th class="py-2 pr-4 font-medium">Type</th>
+          <th class="py-2 pr-4 font-medium">Recipients</th>
+          <th class="py-2 pr-4 font-medium">Sent</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @sent.each do |notification| %>
+          <tr class="border-b border-yin-700">
+            <td class="py-2 pr-4"><%= notification.team.name.presence || "—" %></td>
+            <td class="py-2 pr-4"><%= notification.label %></td>
+            <td class="py-2 pr-4"><%= notification.recipient_count %></td>
+            <td class="py-2 pr-4"><%= notification.created_at.strftime("%b %-d, %Y %-I:%M %p") %> UTC</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <% if @sent.empty? %>
+      <%= render EmptySectionNoticeComponent.new(text: "No notifications have been sent yet.") %>
+    <% end %>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     resources :teams, only: %i[index destroy]
     resources :users, only: :index
     resources :slack_installations, only: :index
+    resources :notifications, only: :index
   end
 
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20260803000000_create_notifications.rb
+++ b/db/migrate/20260803000000_create_notifications.rb
@@ -1,0 +1,15 @@
+class CreateNotifications < ActiveRecord::Migration[8.0]
+  def change
+    create_table :notifications do |t|
+      t.string :team_id, null: false
+      t.string :kind, null: false
+      t.integer :recipient_count, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :notifications, :team_id
+    add_index :notifications, :created_at
+    add_foreign_key :notifications, :teams
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_26_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_03_000000) do
   create_table "data", id: :string, force: :cascade do |t|
     t.string "team_id", null: false
     t.string "name", limit: 120, null: false
@@ -19,6 +19,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_26_000000) do
     t.datetime "updated_at", null: false
     t.index ["name", "created_at"], name: "index_data_on_name_and_created_at"
     t.index ["team_id"], name: "index_data_on_team_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.string "team_id", null: false
+    t.string "kind", null: false
+    t.integer "recipient_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_notifications_on_created_at"
+    t.index ["team_id"], name: "index_notifications_on_team_id"
   end
 
   create_table "pending_seats", force: :cascade do |t|
@@ -114,6 +124,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_26_000000) do
   end
 
   add_foreign_key "data", "teams"
+  add_foreign_key "notifications", "teams"
   add_foreign_key "pending_seats", "teams"
   add_foreign_key "seats", "teams"
   add_foreign_key "seats", "users"

--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class Admin::DashboardControllerTest < ActionDispatch::IntegrationTest
+  test "super admin sees the dashboard with a notifications card" do
+    sign_in(users(:super_admin))
+
+    get admin_root_path
+
+    assert_response :success
+    assert_select "a[href=?]", admin_notifications_path
+  end
+
+  test "a non super admin is redirected away from the dashboard" do
+    sign_in(users(:owner))
+
+    get admin_root_path
+
+    assert_redirected_to dashboard_path
+  end
+end

--- a/test/controllers/admin/notifications_controller_test.rb
+++ b/test/controllers/admin/notifications_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Admin::NotificationsControllerTest < ActionDispatch::IntegrationTest
+  test "super admin can view scheduled and sent notifications" do
+    team = teams(:slack_team)
+    team.notifications.create!(kind: Notification::STATUS_LIST, recipient_count: 3)
+    sign_in(users(:super_admin))
+
+    get admin_notifications_path
+
+    assert_response :success
+    assert_select "h2", text: "Scheduled"
+    assert_select "h2", text: "Recently Sent"
+    # The slack_team is connected, so it shows up in the scheduled list.
+    assert_select "td", text: teams(:slack_team).name
+  end
+
+  test "a non super admin is redirected away from notifications" do
+    sign_in(users(:owner))
+
+    get admin_notifications_path
+
+    assert_redirected_to dashboard_path
+  end
+end

--- a/test/jobs/slack_list_status_job_test.rb
+++ b/test/jobs/slack_list_status_job_test.rb
@@ -33,4 +33,14 @@ class SlackListStatusJobTest < ActiveJob::TestCase
 
     assert(client.verify)
   end
+
+  test "records a sent notification with the recipient count" do
+    with_stubbed_slack_client do
+      SlackListStatusJob.perform_now(@slack_team.id)
+    end
+
+    notifications = @slack_team.notifications.where(kind: Notification::STATUS_LIST)
+    assert_equal 1, notifications.count
+    assert_equal 2, notifications.last.recipient_count
+  end
 end

--- a/test/jobs/slack_status_reminder_job_test.rb
+++ b/test/jobs/slack_status_reminder_job_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class SlackStatusReminderJobTest < ActiveJob::TestCase
+  def with_stubbed_slack_client
+    mock_slack_client = Minitest::Mock.new
+    mock_slack_client.expect :chat_postEphemeral, true, channel: @slack_team.name, user: @slack_user_1.slack_user_id, blocks: Array
+    mock_slack_client.expect :chat_postEphemeral, true, channel: @slack_team.name, user: @slack_user_2.slack_user_id, blocks: Array
+
+    Slack::Web::Client.stub :new, mock_slack_client do
+      yield
+    end
+
+    mock_slack_client
+  end
+
+  setup do
+    @slack_installation = slack_installations(:default)
+    @slack_team = teams(:slack_team)
+    @slack_user_1 = slack_users(:default)
+    @slack_user_2 = slack_users(:rando)
+    seats(:slack_member)
+    seats(:slack_rando)
+  end
+
+  test "handles invalid/missing team ids" do
+    assert_nil(SlackStatusReminderJob.perform_now("invalid-team-id"))
+  end
+
+  test "reminds each user without a status and records the notification" do
+    with_stubbed_slack_client do
+      SlackStatusReminderJob.perform_now(@slack_team.id)
+    end
+
+    notifications = @slack_team.notifications.where(kind: Notification::STATUS_REMINDER)
+    assert_equal 1, notifications.count
+    assert_equal 2, notifications.last.recipient_count
+  end
+end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  test "label maps a known kind to a human string" do
+    assert_equal "Daily digest", Notification.new(kind: Notification::STATUS_LIST).label
+    assert_equal "Status reminder", Notification.new(kind: Notification::STATUS_REMINDER).label
+  end
+
+  test "label falls back to the raw kind" do
+    assert_equal "mystery", Notification.new(kind: "mystery").label
+  end
+
+  test "requires a kind" do
+    notification = Notification.new(team: teams(:slack_team))
+
+    assert_not notification.valid?
+    assert_includes notification.errors[:kind], "can't be blank"
+  end
+end


### PR DESCRIPTION
## Summary

Adds visibility into scheduled and sent notifications for super admins.

A new **Notifications** page in the admin area (linked from the dashboard) shows:

- **Scheduled** — the next status reminder and daily digest for each Slack-connected team, computed from the team's configured notification time and zone. This mirrors exactly what `DailyScheduleStatusReminderJob` / `DailyScheduleListStatusJob` enqueue (reminder one hour before the digest, weekdays), so it's an accurate forward view without depending on queue internals.
- **Recently sent** — a log of digests/reminders actually delivered, with recipient counts and timestamps (most recent first).

### Why a new table

Solid Queue's tables live in a **separate `queue` database** in production (`config/database.yml`) and don't exist in dev/test, so they can't be reliably queried from the app. Instead, sends are recorded in an app-owned `notifications` table: `SlackListStatusJob` and `SlackStatusReminderJob` now create a `Notification` (with `kind` and `recipient_count`) each time they run.

## Changes
- Migration + `Notification` model (`belongs_to :team`, `kind`, `recipient_count`); `Team has_many :notifications, dependent: :destroy`.
- `SlackListStatusJob` / `SlackStatusReminderJob` record a `Notification` with the recipient count.
- `Admin::NotificationsController#index` (scheduled computed + sent from the log) and view; route under `admin`.
- Admin dashboard: "Notifications sent today" card linking to the page.

## Tests
- `Notification#label` mapping and `kind` presence validation.
- Both jobs record a notification with the correct kind and recipient count.
- Super admin can view the notifications page (scheduled + sent sections render, connected team listed); a non-super-admin is redirected.
- Admin dashboard renders with the new card.

Full suite passes (the 5 pre-existing `RegistrationsControllerTest` errors are unrelated sandbox encryption/captcha config, identical on `main`). Rubocop, erb_lint, and `zeitwerk:check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeES7C3scdnuFXRDh2gV1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeES7C3scdnuFXRDh2gV1i)_