### PR TITLE
Show team time zone and scheduled notification time in admin dashboard

### DIFF
--- a/app/views/admin/teams/index.html.erb
+++ b/app/views/admin/teams/index.html.erb
@@ -9,6 +9,9 @@
         <th class="py-2 pr-4 font-medium">Name</th>
         <th class="py-2 pr-4 font-medium">Owner</th>
         <th class="py-2 pr-4 font-medium">Members</th>
+        <th class="py-2 pr-4 font-medium">Time Zone</th>
+        <th class="py-2 pr-4 font-medium">Notify at</th>
+        <th class="py-2 pr-4 font-medium">Next send</th>
         <th class="py-2 pr-4 font-medium">Created</th>
         <th class="py-2 pr-4 font-medium sr-only">Actions</th>
       </tr>
@@ -19,6 +22,9 @@
           <td class="py-2 pr-4"><%= team.name %></td>
           <td class="py-2 pr-4"><%= team.user&.email_address %></td>
           <td class="py-2 pr-4"><%= team.member_count %></td>
+          <td class="py-2 pr-4"><%= team.time_zone.presence || "—" %></td>
+          <td class="py-2 pr-4"><%= team.original_notification_time&.strftime("%l:%M %p")&.strip || "—" %></td>
+          <td class="py-2 pr-4 whitespace-nowrap"><%= team.original_notification_time ? team.notification_time.strftime("%a %l:%M %p %Z").squish : "—" %></td>
           <td class="py-2 pr-4"><%= team.created_at.strftime("%B %d, %Y") %></td>
           <td class="py-2 pr-4 text-right">
             <%= button_to "Delete",


### PR DESCRIPTION
## Summary

Adds notification-timing visibility to the admin **Teams** dashboard so a misconfigured time zone — which fires daily notifications at the wrong wall-clock time — is obvious at a glance.

Three new columns:

- **Time Zone** — the team's configured `time_zone` (e.g. `Central Time (US & Canada)` vs `UTC`).
- **Notify at** — the configured local time (e.g. `4:37 PM`).
- **Next send** — the next occurrence resolved in the team's own zone, including the zone abbreviation (e.g. `Fri 4:37 PM CDT` vs `Fri 4:37 PM UTC`). This is the diagnostic: if it reads `UTC`, notifications fire ~5 hours early for a Central team.

## Context

Investigating reports of improperly-timed Slack notifications: the model schedules `notification_time` in `team.time_zone` (correct, and covered by tests), so a send that lands exactly one UTC offset early indicates the team's `time_zone` is set to UTC rather than the intended local zone. These columns surface that directly.

The cells are defensive against a null notification time so the page can't 500 on unexpected data.

## Testing notes

The container used for this work has no gem bundle, so Rails could not be booted. `strftime`/formatting output was verified in standalone Ruby; runtime verification should be done in a normal environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkD3cproxdzW24ZpG2baTc)_