### PR TITLE
Admin notification diagnostics: local-zone sent times + weekday-accurate next send

### DIFF
--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -14,8 +14,8 @@ class Admin::NotificationsController < Admin::BaseController
   def scheduled_notifications
     Team.where.not(slack_installation_id: nil).includes(:slack_installation).flat_map do |team|
       [
-        { team:, kind: Notification::STATUS_REMINDER, at: team.notification_time - 1.hour },
-        { team:, kind: Notification::STATUS_LIST, at: team.notification_time }
+        { team:, kind: Notification::STATUS_REMINDER, at: team.next_notification_time - 1.hour },
+        { team:, kind: Notification::STATUS_LIST, at: team.next_notification_time }
       ]
     end.sort_by { |entry| entry[:at] }
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -28,6 +28,13 @@ class Team < ApplicationRecord
     next_occurrence_in_team_zone(self.original_notification_time)
   end
 
+  # The next time a digest actually goes out. Daily sends only run on weekdays
+  # (see config/recurring.yml), so roll a weekend occurrence forward to Monday
+  # rather than implying a Saturday/Sunday send that never happens.
+  def next_notification_time
+    skip_weekend(notification_time)
+  end
+
   # The resolved time zone (never nil), for converting stored UTC timestamps
   # into the team's local wall clock.
   def zone
@@ -84,6 +91,16 @@ class Team < ApplicationRecord
   end
 
   private
+
+  # Roll a Saturday/Sunday occurrence forward to Monday, preserving the local
+  # wall-clock time. Adding whole days keeps the same hour across DST changes.
+  def skip_weekend(time)
+    case time.wday
+    when 6 then time + 2.days # Saturday -> Monday
+    when 0 then time + 1.day  # Sunday -> Monday
+    else time
+    end
+  end
 
   # Always resolve to a valid zone. A blank or unrecognized `time_zone` would
   # otherwise make `ActiveSupport::TimeZone[...]` return nil (or raise on nil),

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -28,6 +28,12 @@ class Team < ApplicationRecord
     next_occurrence_in_team_zone(self.original_notification_time)
   end
 
+  # The resolved time zone (never nil), for converting stored UTC timestamps
+  # into the team's local wall clock.
+  def zone
+    team_zone
+  end
+
   def previous_cutoff
     next_cutoff - 1.day
   end

--- a/app/views/admin/notifications/index.html.erb
+++ b/app/views/admin/notifications/index.html.erb
@@ -51,7 +51,7 @@
             <td class="py-2 pr-4"><%= notification.team.name.presence || "—" %></td>
             <td class="py-2 pr-4"><%= notification.label %></td>
             <td class="py-2 pr-4"><%= notification.recipient_count %></td>
-            <td class="py-2 pr-4"><%= notification.created_at.strftime("%b %-d, %Y %-I:%M %p") %> UTC</td>
+            <td class="py-2 pr-4 whitespace-nowrap"><%= notification.created_at.in_time_zone(notification.team.zone).strftime("%b %-d, %Y %-I:%M %p %Z") %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/teams/index.html.erb
+++ b/app/views/admin/teams/index.html.erb
@@ -24,7 +24,7 @@
           <td class="py-2 pr-4"><%= team.member_count %></td>
           <td class="py-2 pr-4"><%= team.time_zone.presence || "—" %></td>
           <td class="py-2 pr-4"><%= team.original_notification_time&.strftime("%l:%M %p")&.strip || "—" %></td>
-          <td class="py-2 pr-4 whitespace-nowrap"><%= team.original_notification_time ? team.notification_time.strftime("%a %l:%M %p %Z").squish : "—" %></td>
+          <td class="py-2 pr-4 whitespace-nowrap"><%= team.original_notification_time ? team.next_notification_time.strftime("%a %l:%M %p %Z").squish : "—" %></td>
           <td class="py-2 pr-4"><%= team.created_at.strftime("%B %d, %Y") %></td>
           <td class="py-2 pr-4 text-right">
             <%= button_to "Delete",


### PR DESCRIPTION
## Summary

Follow-up to #70, improving the admin notification-timing diagnostics so a mis-timed daily digest is easy to spot and interpret.

- **Recently Sent times now render in each team's local zone** (was UTC), with the zone abbreviation — e.g. `Aug 7, 2026 9:37 AM CDT`. This makes *actual* send times directly comparable to the scheduled send. (Adds `Team#zone`, a resolved-never-nil time zone.)
- **Next send preview now skips weekends.** Daily sends only run on weekdays (`config/recurring.yml`: `0 0 * * 1-5`), but the preview used a naive next-occurrence that could show a Saturday/Sunday date no send happens on. `Team#next_notification_time` rolls a weekend occurrence forward to Monday (preserving local wall-clock across DST), and the admin Teams + Notifications previews use it.

## Why

While investigating reports of mis-timed Slack notifications, the admin data showed the digest **scheduled** at `9:37 AM CDT` but **actually sent** at `9:37 AM UTC` — the sends fired while the team's zone was effectively UTC. Surfacing actual send times in the team's zone makes that mismatch obvious, and the weekday-accurate preview stops the "Next send" from implying a weekend send that never arrives.

## Testing notes

The container has no gem bundle, so Rails could not be booted. Verified with Ruby syntax checks and a standalone simulation of the weekend-skip logic (Sat/Sun → Mon, weekdays unchanged). Runtime verification should be done in a normal environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkD3cproxdzW24ZpG2baTc)_